### PR TITLE
Add CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+hidimstat.org

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <title>hidimstat</title>
     <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
-    <link rel="canonical" href="https://hidimstat.github.io" />
+    <link rel="canonical" href="https://hidimstat.org" />
   </head>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <title>hidimstat</title>
     <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
-    <link rel="canonical" href="https://hidimstat.org" />
+    <link rel="canonical" href="https://hidimstat.org" /> <!-- See CNAME for the domain name -->
   </head>
 
 </html>


### PR DESCRIPTION
CNAME file is used for declaration an alias of another domain name.
For more information see: https://support.google.com/a/answer/112037?hl=en#zippy=%2Cset-up-cname-records-now

This means that it requires buying a domain name for this functionality. 